### PR TITLE
fix(vite): set base to './' in config for correct static deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,4 +11,5 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  base: "./",
 })


### PR DESCRIPTION
Set the base option to './' in vite.config.js to ensure that static assets load correctly when deploying the app to a subdirectory or static hosting environment (like Plesk).

This prevents broken links to JS/CSS files and fixes blank page issues in production builds. No changes to application logic.

<img width="1906" height="843" alt="image" src="https://github.com/user-attachments/assets/e700e83e-98d0-4831-949f-945d0dca553d" />
